### PR TITLE
feat(homesection.svelte): added name expansion on resize

### DIFF
--- a/src/lib/sections/HomeSection.svelte
+++ b/src/lib/sections/HomeSection.svelte
@@ -25,7 +25,13 @@
       <h1 class="text-xl font-extrabold">
         <span class="text-lime-400">HI</span> THERE! I'M
       </h1>
-      <p class="mb-4 text-6xl font-semibold break-words">Chris Sterza</p>
+      <!-- #TODO: redo this in a more svelte-eque way. -->
+      <p class="mb-4 text-6xl font-semibold break-words md:hidden">
+        Chris Sterza
+      </p>
+      <p class="hidden mb-4 text-6xl font-semibold break-words md:block">
+        Christopher Sterza
+      </p>
 
       <!-- Description List -->
       <ul class="list-inside list text-lime-400 text-xl mb-6">


### PR DESCRIPTION
Made the name in the home section of the site expand from Chris to Christopher on larger devices.