### PR TITLE
refactor: changed section structure

### DIFF
--- a/src/lib/components/Footer.svelte
+++ b/src/lib/components/Footer.svelte
@@ -1,15 +1,7 @@
 <script></script>
 
-<footer class="container flex flex-col mx-auto mb-12 text-white">
-  <div class="pt-10 mx-4 mb-6 sm:border-l-4 sm:border-lime-400">
-    <!-- Dot -->
-    <span
-      class="hidden relative w-[20px] h-[20px] bg-lime-400 rounded-full -left-3 shrink-0 sm:block"
-    />
-  </div>
-  <div class="flex flex-col items-center mx-4 text-gray-300/50">
-    <p>
-      Made with <span class="text-lime-400">❤</span> by Christopher Sterza
-    </p>
-  </div>
+<footer class="flex flex-col items-center mb-8 text-gray-400">
+  <p>
+    Made with <span class="text-lime-400">❤</span> by Christopher Sterza
+  </p>
 </footer>

--- a/src/lib/components/Headshot.svelte
+++ b/src/lib/components/Headshot.svelte
@@ -1,14 +1,12 @@
 <script>
   import headshot from '$lib/assets/png/headshot.png';
+
+  let imageSize = `max-w-[250px] sm:max-w-[350px]`;
 </script>
 
-<div class="w-[255px] h-[255px] pointer-events-none sm:w-[305px] sm:h-[305px]">
+<div class="relative pointer-events-none {imageSize}">
   <div
-    class="w-[255px] h-[255px] bg-lime-400 rounded-full absolute shadow-xl shadow-lime-900 sm:w-[305px] sm:h-[305px]"
+    class="absolute w-full h-full rounded-full shadow-xl -left-2 -bottom-2 bg-lime-400 shadow-lime-900"
   />
-  <img
-    src={headshot}
-    alt="Headshot"
-    class="w-[250px] h-auto rounded-full relative left-2 bottom-2 sm:w-[300px]"
-  />
+  <img src={headshot} alt="Headshot" class="relative rounded-full" />
 </div>

--- a/src/lib/components/Section.svelte
+++ b/src/lib/components/Section.svelte
@@ -1,0 +1,45 @@
+<script>
+  export let isTop = false;
+  export let isBottom = false;
+
+  let borderClass = 'sm:border-l-[3px]';
+  let sectionSize = '';
+  let flexJustification = '';
+  let topDotPosition = 'top-[100px]';
+
+  if (isTop) {
+    borderClass += ' myBorder';
+    sectionSize = 'min-h-screen';
+    flexJustification = 'justify-center';
+    topDotPosition = 'top-[39%]';
+  } else {
+    borderClass += ' border-lime-400';
+  }
+</script>
+
+<section
+  class="relative flex flex-col mx-auto px-7 py-20 sm:pl-16 text-white sm:w-4/5 max-w-screen-2xl {borderClass} {sectionSize} {flexJustification}"
+>
+  <!-- Top Dot -->
+  <span
+    class="hidden absolute w-[21px] h-[21px] bg-lime-400 rounded-full shrink-0 sm:block -left-[12px] {topDotPosition}"
+  />
+  <slot />
+  {#if isBottom}
+    <!-- Bottom Dot -->
+    <span
+      class="hidden absolute w-[21px] h-[21px] bg-lime-400 rounded-full sm:block shrink-0 -left-[12px] bottom-0"
+    />
+  {/if}
+</section>
+
+<style lang="postcss">
+  .myBorder {
+    border-image: linear-gradient(
+        to top,
+        theme('colors.lime.400') 60%,
+        transparent 40%
+      )
+      1;
+  }
+</style>

--- a/src/lib/sections/HomeSection.svelte
+++ b/src/lib/sections/HomeSection.svelte
@@ -1,4 +1,5 @@
 <script>
+  import Section from '../components/Section.svelte';
   import Headshot from '../components/Headshot.svelte';
 
   let linkedinURL = 'https://www.linkedin.com/in/christophersterza';
@@ -6,89 +7,80 @@
   let twitterURL = 'https://twitter.com/ChrisSterza';
 </script>
 
-<section
-  class="container flex flex-col justify-center h-screen mx-auto text-white"
->
-  <!-- Spacer -->
-  <div class="h-[35%]" />
-  <div class="h-[65%] flex flex-col sm:border-l-4 sm:border-lime-400 mx-4">
-    <span
-      class="hidden relative w-[20px] h-[20px] bg-lime-400 rounded-full -left-3 shrink-0 sm:block"
-    />
-    <div class="flex flex-col ml-4 w-fit sm:ml-20">
-      <!-- Headshot -->
-      <div id="headshotWrapper" class="mb-8 -mt-48">
-        <Headshot />
-      </div>
+<Section isTop={true}>
+  <div class="flex flex-col w-fit">
+    <!-- Headshot -->
+    <div id="headshotWrapper" class="mb-8">
+      <Headshot />
+    </div>
 
-      <!-- Title Text -->
-      <h1 class="text-xl font-extrabold">
-        <span class="text-lime-400">HI</span> THERE! I'M
-      </h1>
-      <!-- #TODO: redo this in a more svelte-eque way. -->
-      <p class="mb-4 text-6xl font-semibold break-words md:hidden">
-        Chris Sterza
-      </p>
-      <p class="hidden mb-4 text-6xl font-semibold break-words md:block">
-        Christopher Sterza
-      </p>
+    <!-- Title Text -->
+    <h1 class="text-xl font-extrabold">
+      <span class="text-lime-400">HI</span> THERE! I'M
+    </h1>
+    <!-- #TODO: redo this in a more svelte-eque way. -->
+    <p class="mb-4 text-6xl font-semibold break-words lg:hidden">
+      Chris Sterza
+    </p>
+    <p class="hidden mb-4 text-6xl font-semibold break-words lg:block">
+      Christopher Sterza
+    </p>
 
-      <!-- Description List -->
-      <ul class="mb-6 text-xl list-inside list text-lime-400">
-        <li class="flex flex-row items-center">
-          <span
-            class="block w-[12px] h-[3px] mr-4 bg-lime-400 rounded-full shrink-0"
-          />
-          <span class="block font-normal">full stack developer</span>
-        </li>
-        <li class="flex flex-row items-center">
-          <span
-            class="block w-[12px] h-[3px] mr-4 bg-lime-400 rounded-full shrink-0"
-          />
-          <span class="block font-normal">designer</span>
-        </li>
-        <li class="flex flex-row items-center">
-          <span
-            class="block w-[12px] h-[3px] mr-4 bg-lime-400 rounded-full shrink-0"
-          />
-          <span class="block font-normal">animal lover</span>
-        </li>
-      </ul>
+    <!-- Description List -->
+    <ul class="mb-6 text-xl list-inside list text-lime-400">
+      <li class="flex flex-row items-center">
+        <span
+          class="block w-[12px] h-[3px] mr-4 bg-lime-400 rounded-full shrink-0"
+        />
+        <span class="block font-normal">full stack developer</span>
+      </li>
+      <li class="flex flex-row items-center">
+        <span
+          class="block w-[12px] h-[3px] mr-4 bg-lime-400 rounded-full shrink-0"
+        />
+        <span class="block font-normal">designer</span>
+      </li>
+      <li class="flex flex-row items-center">
+        <span
+          class="block w-[12px] h-[3px] mr-4 bg-lime-400 rounded-full shrink-0"
+        />
+        <span class="block font-normal">animal lover</span>
+      </li>
+    </ul>
 
-      <!-- Socials -->
-      <div class="flex flex-row mb-6">
-        <a href={linkedinURL} target="_blank" rel="noreferrer">
-          <i
-            class="mr-2 text-5xl transition duration-300 ease-in-out bx bxl-linkedin opacity-60 hover:opacity-100"
-          />
-        </a>
-        <a href={githubURL} target="_blank" rel="noreferrer">
-          <i
-            class="mr-2 text-5xl transition duration-300 ease-in-out bx bxl-github opacity-60 hover:opacity-100"
-          />
-        </a>
-        <a href={twitterURL} target="_blank" rel="noreferrer">
-          <i
-            class="mr-2 text-5xl transition duration-300 ease-in-out bx bxl-twitter opacity-60 hover:opacity-100"
-          />
-        </a>
-      </div>
+    <!-- Socials -->
+    <div class="flex flex-row mb-6">
+      <a href={linkedinURL} target="_blank" rel="noreferrer">
+        <i
+          class="mr-2 text-5xl transition duration-300 ease-in-out bx bxl-linkedin opacity-60 hover:opacity-100"
+        />
+      </a>
+      <a href={githubURL} target="_blank" rel="noreferrer">
+        <i
+          class="mr-2 text-5xl transition duration-300 ease-in-out bx bxl-github opacity-60 hover:opacity-100"
+        />
+      </a>
+      <a href={twitterURL} target="_blank" rel="noreferrer">
+        <i
+          class="mr-2 text-5xl transition duration-300 ease-in-out bx bxl-twitter opacity-60 hover:opacity-100"
+        />
+      </a>
+    </div>
 
-      <!-- Buttons -->
-      <div class="flex flex-col gap-4 mb-6 sm:flex-row">
-        <button
-          id="projectButton"
-          class="w-11/12 bg-lime-600 rounded-full px-4 py-1 text-lg font-semibold sm:w-1/2 hover:bg-lime-800 transition ease-in-out duration-200 hover:-skew-y-[8deg] hover:rotate-[8deg]"
-        >
-          Projects
-        </button>
-        <button
-          id="skillButton"
-          class="flex justify-center w-11/12 bg-lime-600 rounded-full px-4 py-1 text-lg font-semibold sm:w-1/2 hover:bg-lime-800 transition ease-in-out duration-200 hover:-skew-y-[8deg] hover:rotate-[8deg]"
-        >
-          Skills
-        </button>
-      </div>
+    <!-- Buttons -->
+    <div class="flex flex-col gap-4 mb-6 sm:flex-row">
+      <button
+        id="projectButton"
+        class="w-full bg-lime-600 rounded-full px-4 py-1 text-lg font-semibold sm:w-1/2 hover:bg-lime-800 transition ease-in-out duration-200 hover:-skew-y-[8deg] hover:rotate-[8deg]"
+      >
+        Projects
+      </button>
+      <button
+        id="skillButton"
+        class="flex justify-center w-full bg-lime-600 rounded-full px-4 py-1 text-lg font-semibold sm:w-1/2 hover:bg-lime-800 transition ease-in-out duration-200 hover:-skew-y-[8deg] hover:rotate-[8deg]"
+      >
+        Skills
+      </button>
     </div>
   </div>
-</section>
+</Section>

--- a/src/lib/sections/ProjectSection.svelte
+++ b/src/lib/sections/ProjectSection.svelte
@@ -1,37 +1,29 @@
 <script>
+  import Section from '../components/Section.svelte';
   import ProjectCard from '../components/ProjectCard.svelte';
   import projectData from '../data/projects.json';
   let projects = projectData.projects;
 </script>
 
-<section id="ProjectSection" class="container flex flex-col mx-auto text-white">
-  <div
-    class="flex flex-col mx-4 mt-40 sm:mt-0 sm:border-l-4 sm:border-lime-400"
-  >
-    <!-- Dot -->
-    <span
-      class="hidden relative w-[20px] h-[20px] bg-lime-400 rounded-full -left-3 -bottom-[50px] shrink-0 sm:block"
-    />
-    <div class="flex flex-col mx-4 sm:ml-20">
-      <h1 class="mb-2 text-6xl">Projects</h1>
-      <h2 class="mb-16 text-xl">
-        Here are some of my projects. Hover them for more information.
-      </h2>
+<div id="projectAnchor" />
+<Section>
+  <h1 class="mb-2 text-6xl font-medium">Projects</h1>
+  <h2 class="mb-16 text-xl">
+    Here are some of my projects. Hover them for more information.
+  </h2>
 
-      <!-- Project cards -->
-      <div class="flex flex-row flex-wrap w-full gap-x-8 gap-y-7">
-        {#each projects as project}
-          <ProjectCard
-            name={project.name || ''}
-            description={project.description || ''}
-            thumbnail={project.thumbnailImage || ''}
-            thumbnailScale={project.thumbnailScale || '1'}
-            languages={project.languages || ''}
-            liveURL={project.liveURL || ''}
-            sourceURL={project.sourceURL || ''}
-          />
-        {/each}
-      </div>
-    </div>
+  <!-- Project cards -->
+  <div id="projectList" class="flex flex-row flex-wrap w-full gap-x-8 gap-y-7">
+    {#each projects as project}
+      <ProjectCard
+        name={project.name || ''}
+        description={project.description || ''}
+        thumbnail={project.thumbnailImage || ''}
+        thumbnailScale={project.thumbnailScale || '1'}
+        languages={project.languages || ''}
+        liveURL={project.liveURL || ''}
+        sourceURL={project.sourceURL || ''}
+      />
+    {/each}
   </div>
-</section>
+</Section>

--- a/src/lib/sections/SkillSection.svelte
+++ b/src/lib/sections/SkillSection.svelte
@@ -1,4 +1,5 @@
 <script>
+  import Section from '../components/Section.svelte';
   import SkillCard from '../components/SkillCard.svelte';
   import skillData from '../data/skills.json';
   let skills = skillData.skills;
@@ -9,28 +10,21 @@
   });
 </script>
 
-<section id="SkillSection" class="container flex flex-col mx-auto text-white">
-  <div class="flex flex-col pt-40 mx-4 sm:border-l-4 sm:border-lime-400">
-    <!-- Dot -->
-    <span
-      class="hidden relative w-[20px] h-[20px] bg-lime-400 rounded-full -left-3 -bottom-[50px] shrink-0 sm:block"
-    />
-    <div class="flex flex-col mx-4 sm:ml-20">
-      <h1 class="mb-2 text-6xl">Skills</h1>
-      <h2 class="mb-16 text-xl">
-        Here are some of my skills and areas of knowledge.
-      </h2>
+<div id="skillAnchor" />
+<Section isBottom={true}>
+  <h1 class="mb-2 text-6xl font-medium">Skills</h1>
+  <h2 class="mb-16 text-xl">
+    Here are some of my skills and areas of knowledge.
+  </h2>
 
-      <!-- Skill cards -->
-      <div class="flex flex-col gap-y-7">
-        {#each skills as skill}
-          <SkillCard
-            name={skill.name || ''}
-            knowledgeLevel={skill.knowledgeLevel || 0}
-            labels={skill.labels || []}
-          />
-        {/each}
-      </div>
-    </div>
+  <!-- Skill cards -->
+  <div class="flex flex-col gap-y-7">
+    {#each skills as skill}
+      <SkillCard
+        name={skill.name || ''}
+        knowledgeLevel={skill.knowledgeLevel || 0}
+        labels={skill.labels || []}
+      />
+    {/each}
   </div>
-</section>
+</Section>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,17 +1,17 @@
 <script>
   import { onMount } from 'svelte';
   import BackgroundComponent from '../lib/components/BackgroundComponent.svelte';
-  import Footer from '../lib/components/Footer.svelte';
   import LoadingScreen from '../lib/components/LoadingScreen.svelte';
   import HomeSection from '../lib/sections/HomeSection.svelte';
   import ProjectSection from '../lib/sections/ProjectSection.svelte';
   import SkillSection from '../lib/sections/SkillSection.svelte';
+  import Footer from '../lib/components/Footer.svelte';
 
   let isLoading = true;
 
   onMount(() => {
-    let projectSection = document.getElementById('ProjectSection');
-    let skillSection = document.getElementById('SkillSection');
+    let projectSection = document.getElementById('projectAnchor');
+    let skillSection = document.getElementById('skillAnchor');
 
     let projectButton = document.getElementById('projectButton');
     let skillButton = document.getElementById('skillButton');


### PR DESCRIPTION
The way in which the sections of the site were structured before allowed the home section to overlap
with the project section while landscape on mobile devices.

I've restructured the way the sections on the page work by abstracting away a Section component.
This allowed me to make the margin, padding, and borders of all sections of the site uniform.
In turn, this simplified the code for the sections significantly and allowed me to focus on
what specifically was causing the sections to overlap.

While landscape on mobile devices no longer causes the sections to overlap, they're still ugly
in this view. Maybe come back to it later.